### PR TITLE
Fix npm publish OIDC auth broken by setup-node registry-url

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,8 +14,6 @@ runs:
     steps:
         - if: ${{ inputs.install_node == 'true' }}
           uses: actions/setup-node@v4
-          with:
-              registry-url: "https://registry.npmjs.org/"
 
         - uses: oven-sh/setup-bun@v2
           with:


### PR DESCRIPTION
## Problem

`actions/setup-node` with `registry-url` automatically writes an `.npmrc` that sets `NODE_AUTH_TOKEN` as the auth mechanism. This overrides npm's OIDC trusted publishing flow, causing a `404` on `npm publish` even though `id-token: write` is set.

## Fix

Remove `registry-url` from the shared setup action. The `NODE_AUTH_TOKEN` is still set per-step (env) for `npm show` and `npm deprecate`, which is sufficient. `npm publish` now uses OIDC unobstructed.