### PR TITLE
Update valibot peer dependency to >= 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@valibot/to-json-schema": "^1.6.0"
     },
     "peerDependencies": {
-        "valibot": ">= 0.31.0"
+        "valibot": ">= 1.0.0"
     },
     "optionalDependencies": {
         "esbuild-runner": ">= 2.2.2"


### PR DESCRIPTION
## Summary
- Update `peerDependencies.valibot` from `>= 0.31.0` to `>= 1.0.0` to reflect the valibot 1.x requirement introduced by `@valibot/to-json-schema@1.6.0`