### PR TITLE
Fix CD workflow for npm trusted publishing (OIDC)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,10 @@ runs:
     using: composite
     steps:
         - if: ${{ inputs.install_node == 'true' }}
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v6
+          with:
+              node-version: "24"
+              registry-url: "https://registry.npmjs.org"
 
         - uses: oven-sh/setup-bun@v2
           with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,8 +43,6 @@ jobs:
 
             - name: "Create version"
               id: version
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
                   set -x # verbose
                   message=$(git show -s --format=%s)
@@ -83,12 +81,6 @@ jobs:
             - name: "Publish"
               run: npm publish --access public --tag ${{ steps.version.outputs.publishTag }}
 
-            - name: "Deprecate previous snapshot"
-              if: ${{ steps.version.outputs.previousVersion != '' }}
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: npm deprecate ${{ steps.version.outputs.name }}@${{ steps.version.outputs.previousVersion }} "snapshot"
-
     prepare-release:
         if: ${{ inputs.releaseType != '' && github.ref_name == 'main'  }}
         needs: ci
@@ -108,7 +100,6 @@ jobs:
 
             - name: "Bump version"
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   GH_TOKEN: ${{ secrets.GH_PRRELEASE }}
               run: |
                   set -x

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "esbuild-runner": ">= 2.2.2",
       },
       "peerDependencies": {
-        "valibot": ">= 0.31.0",
+        "valibot": ">= 1.0.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
         "bin"
     ],
     "bin": "bin/index.js",
+    "engines": {
+        "node": ">=18"
+    },
     "sideEffects": false,
     "scripts": {
         "build": "tsup",


### PR DESCRIPTION
## Summary

- Add `node-version: "22"` and `registry-url` to `actions/setup-node` in the setup action (trusted publishing requires npm >= 11.5.1 / Node >= 22.14.0)
- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` secret references from publish and version steps (OIDC handles auth automatically)
- Remove "Deprecate previous snapshot" step (`npm deprecate` does not support OIDC, only `npm publish` does)